### PR TITLE
Add output param to xcpretty

### DIFF
--- a/guide/xcpretty.rst
+++ b/guide/xcpretty.rst
@@ -17,13 +17,13 @@ Running ``xcpretty`` is quite straight forward. For example, the command below w
 
 .. code-block:: bash
 
-  xcodebuild [flags] | xcpretty -r json-compilation-database
+  xcodebuild [flags] | xcpretty -r json-compilation-database -o compile_commands.json
 
 If you want to preserve the raw xcodebuild output, then you can do
 
 .. code-block:: bash
 
-  xcodebuild [flags] | tee xcodebuild.log | xcpretty -r json-compilation-database
+  xcodebuild [flags] | tee xcodebuild.log | xcpretty -r json-compilation-database -o compile_commands.json
 
 Running oclint-json-compilation-database
 ----------------------------------------


### PR DESCRIPTION
Was confused when the `compile_commands.json` wasn't appearing, this fixes that. ^___^